### PR TITLE
Fix module resolution.

### DIFF
--- a/lib/ruby_decorators.rb
+++ b/lib/ruby_decorators.rb
@@ -12,7 +12,7 @@ module RubyDecorators
 
     private
 
-    def resolve_method(method_name, *args, klass:, &blk)
+    def resolve_method(method_name, args, klass:, &blk)
       decorators = nil
       method = nil
       klass.ancestors.each do |klass|
@@ -53,7 +53,7 @@ module RubyDecorators
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       #{method_visibility_for(method_name)}
       def #{method_name}(*args, &blk)
-        resolve_method(:#{method_name}, *args, klass: #{self}, &blk)
+        resolve_method(:#{method_name}, args, klass: #{self}, &blk)
       end
     RUBY_EVAL
   end

--- a/lib/ruby_decorators.rb
+++ b/lib/ruby_decorators.rb
@@ -8,6 +8,34 @@ module RubyDecorators
     end
   end
 
+  module DecoratorHelperMethods
+
+    private
+
+    def resolve_method(method_name, *args, klass:, &blk)
+      decorators = nil
+      method = nil
+      klass.ancestors.each do |klass|
+
+        decorators = klass.instance_variable_get(:@decorators)[method_name]
+        method = klass.instance_variable_get(:@methods)[method_name]
+
+        if !method.nil?
+          break
+        end
+      end
+
+      decorators.inject(method.bind(self)) do |method, decorator|
+        decorator = decorator.new if decorator.respond_to?(:new)
+        lambda { |*a, &b| decorator.call(method, *a, &b) }
+      end.call(*args, &blk)
+    end
+  end
+
+  def self.extended(klass)
+    klass.include(DecoratorHelperMethods)
+  end
+
   def method_added(method_name)
     super
 
@@ -25,15 +53,24 @@ module RubyDecorators
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       #{method_visibility_for(method_name)}
       def #{method_name}(*args, &blk)
-        decorators = self.class.instance_variable_get(:@decorators)[:#{method_name}]
-        method     = self.class.instance_variable_get(:@methods)[:#{method_name}]
-
-        decorators.inject(method.bind(self)) do |method, decorator|
-          decorator = decorator.new if decorator.respond_to?(:new)
-          lambda { |*a, &b| decorator.call(method, *a, &b) }
-        end.call(*args, &blk)
+        resolve_method(:#{method_name}, *args, klass: #{self}, &blk)
       end
     RUBY_EVAL
+  end
+
+  def included(klass)
+    decorators = klass.instance_variable_get(:@decorators)
+    if decorators.nil?
+      decorators = {}
+      klass.instance_variable_set(:@decorators, decorators)
+    end
+    decorators.merge!(@decorators)
+    methods = klass.instance_variable_get(:@methods)
+    if methods.nil?
+      methods = {}
+      klass.instance_variable_set(:@methods, methods)
+    end
+    methods.merge!(@methods)
   end
 
   private

--- a/lib/ruby_decorators.rb
+++ b/lib/ruby_decorators.rb
@@ -58,21 +58,6 @@ module RubyDecorators
     RUBY_EVAL
   end
 
-  def included(klass)
-    decorators = klass.instance_variable_get(:@decorators)
-    if decorators.nil?
-      decorators = {}
-      klass.instance_variable_set(:@decorators, decorators)
-    end
-    decorators.merge!(@decorators)
-    methods = klass.instance_variable_get(:@methods)
-    if methods.nil?
-      methods = {}
-      klass.instance_variable_set(:@methods, methods)
-    end
-    methods.merge!(@methods)
-  end
-
   private
 
   def method_visibility_for(method_name)

--- a/spec/ruby_decorators_spec.rb
+++ b/spec/ruby_decorators_spec.rb
@@ -38,8 +38,18 @@ describe RubyDecorators do
     end
   end
 
+  module DummyModule
+    extend RubyDecorators
+
+    +Batman
+    def included_from_module
+      @greeting
+    end
+  end
+
   class DummyClass
     extend RubyDecorators
+    include DummyModule
 
     def initialize
       @greeting = 'hello world'
@@ -110,6 +120,27 @@ describe RubyDecorators do
     end
   end
 
+  class ChildDummyClass < DummyClass
+
+    def hello_public
+      @greeting
+    end
+
+    +Batman
+    def hello_catwoman
+      @greeting
+    end
+
+    def hi_batman
+      super
+    end
+
+    +Batman
+    def hello_super_catwoman
+      super
+    end
+  end
+
   subject { DummyClass.new }
 
   it "#hello_world" do
@@ -153,6 +184,30 @@ describe RubyDecorators do
 
     it "ignores undecorated methods" do
       subject.hello_untouched.must_equal 'hello world'
+    end
+
+    it "decorates a method included from an outside module" do
+      subject.included_from_module.must_equal 'hello batman'
+    end
+
+    describe "overridden methods" do
+      subject { ChildDummyClass.new }
+
+      it "ignores decorators of an overridden method" do
+        subject.hello_public.must_equal 'hello world'
+      end
+
+      it "overrides decorators of an overridden method" do
+        subject.hello_catwoman.must_equal 'hello batman'
+      end
+
+      it "calls super method's decorators when super is used" do
+        subject.hi_batman.must_equal 'hi batman'
+      end
+
+      it "calls super method's decorator with super, then calls child methods decorators" do
+        subject.hello_super_catwoman.must_equal 'hello super catwoman'
+      end
     end
   end
 


### PR DESCRIPTION
A few changes in this forked version:

I extracted the stringified ruby logic that resolved the methods and decorators, and now call a private method for that.

Next, I changed the logic that simply looked up the method and decorators from self.class and instead iterate through ancestors to resolve when not defined in the implemented class.